### PR TITLE
Fix block not being passed when aliasing #call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Fixed a bug that wouldn't pass a block if `#call` was aliased (#7)
+
 ### 1.0.2 - 2020-03-02
 
 * Bump `rake` to 12.3.3 (#11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.1.1)
+    coderay (1.1.2)
     diff-lcs (1.3)
+    method_source (0.9.2)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     rake (12.3.3)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -28,6 +37,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.0)
   injectable!
+  pry-byebug
   rake (~> 12.0)
   rspec (~> 3.0)
 

--- a/injectable.gemspec
+++ b/injectable.gemspec
@@ -1,30 +1,29 @@
-
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "injectable/version"
+require 'injectable/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'injectable'
   spec.version       = Injectable::VERSION
-  spec.authors       = %w(Papipo iovis9 jantequera amrocco)
-  spec.email         = %w(rodrigo@rubiconmd.com david.marchante@rubiconmd.com julio@rubiconmd.com anthony@rubiconmd.com)
+  spec.authors       = %w[Papipo iovis9 jantequera amrocco]
+  spec.email         = %w[dev@rubiconmd.com david.marchante@rubiconmd.com julio@rubiconmd.com anthony@rubiconmd.com]
 
-  spec.summary       = %q{A library to help you build nice service objects with dependency injection.}
+  spec.summary       = 'A library to help you build nice service objects with dependency injection.'
   spec.homepage      = 'https://github.com/rubiconmd/injectable'
-  spec.license       = "MIT"
+  spec.license       = 'MIT'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files         = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'pry-byebug'
 end

--- a/injectable.gemspec
+++ b/injectable.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'pry-byebug'
 end

--- a/lib/injectable/dependency.rb
+++ b/lib/injectable/dependency.rb
@@ -16,8 +16,12 @@ module Injectable
     def wrap_call(the_instance)
       return the_instance unless call
 
-      lambda do |*args|
-        the_instance.public_send(call, *args)
+      the_instance.tap do |instance|
+        call_method = call
+
+        instance.define_singleton_method(:call) do |*args, &block|
+          send(call_method, *args, &block)
+        end
       end
     end
 

--- a/spec/injectable/dependencies_graph_spec.rb
+++ b/spec/injectable/dependencies_graph_spec.rb
@@ -1,5 +1,5 @@
 describe Injectable::DependenciesGraph, '#resolve' do
-  let(:ns)    { stub('Namespace') }
+  let(:ns)    { double('Namespace') }
   let(:graph) { described_class.new(namespace: ns) }
 
   context 'when depending on a dependency not declared' do

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -491,6 +491,6 @@ describe Injectable do
 
     subject { [Parent.call, Child.call, Sibling.call] }
 
-    it { is_expected.to eq ['in parent', 'in child', 'in sibling']}
+    it { is_expected.to eq ['in parent', 'in child', 'in sibling'] }
   end
 end

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -519,4 +519,30 @@ describe Injectable do
       expect(subject.call).to eq "can't block this"
     end
   end
+
+  context 'when the dependency accepts a block and has #call aliased' do
+    before do
+      class BlockPasser
+        def run
+          yield
+        end
+      end
+    end
+
+    subject do
+      Class.new do
+        include Injectable
+
+        dependency :block_passer, call: :run
+
+        def call
+          block_passer.call { "can't block this" }
+        end
+      end
+    end
+
+    it 'passes the block to the dependency' do
+      expect(subject.call).to eq "can't block this"
+    end
+  end
 end

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -493,4 +493,30 @@ describe Injectable do
 
     it { is_expected.to eq ['in parent', 'in child', 'in sibling'] }
   end
+
+  context 'when the dependency accepts a block' do
+    before do
+      class BlockPasser
+        def call
+          yield
+        end
+      end
+    end
+
+    subject do
+      Class.new do
+        include Injectable
+
+        dependency :block_passer
+
+        def call
+          block_passer.call { "can't block this" }
+        end
+      end
+    end
+
+    it 'passes the block to the dependency' do
+      expect(subject.call).to eq "can't block this"
+    end
+  end
 end

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -162,8 +162,8 @@ describe Injectable do
   context 'with dependencies that have a call: option' do
     before do
       SomeRenderer = Class.new do
-        def render
-          '#render has been called'
+        def render(arg, kwarg:)
+          "#render has been called with #{arg} and #{kwarg}"
         end
       end
     end
@@ -173,12 +173,15 @@ describe Injectable do
         include Injectable
         extend Forwardable
         dependency :some_renderer, call: :render
-        def_delegators :some_renderer, :call
+
+        def call
+          some_renderer.call('hello', kwarg: 'world')
+        end
       end
     end
 
     it 'wraps the specified method in a #call method' do
-      expect(subject.call).to eq '#render has been called'
+      expect(subject.call).to eq '#render has been called with hello and world'
     end
   end
 


### PR DESCRIPTION
When using `call: :some_method` Injectable returned a lambda that called the method in the dependency.

This had two issues:
1. Blocks were not passed through
2. We were returning a `lambda` object instead of the instance

I tried using `alias_method` with something like:
```rb
# :alias_method is not defined when doing #instance_eval
# See https://stackoverflow.com/questions/35181769/ruby-unexpected-behavior-of-alias-method-when-accessing-an-object
the_instance.instance_eval do
  singleton_class.send :alias_method, call_method, :call
end
```

But never managed to make it work, for some reason.

I opted for just defining `#call` in the instance itself with `define_singleton_method` and make it point to the desired one.

Ran the tests in RubiconMD with the new version after fixing the code that discovered this bug and the tests passed