### PR TITLE
Raise exception if dependency is already callable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Raises exception if shadowing an existing `#call` method in a dependency
+
 ### 1.0.3 - 2020-03-16
 
 * Fixed a bug that wouldn't pass a block if `#call` was aliased (#7)

--- a/lib/injectable.rb
+++ b/lib/injectable.rb
@@ -5,6 +5,7 @@ require 'injectable/dependencies_proxy'
 require 'injectable/dependency'
 require 'injectable/instance_methods'
 require 'injectable/missing_dependencies_exception'
+require 'injectable/method_already_exists_exception'
 
 # Convert your class into an injectable service
 #

--- a/lib/injectable/dependency.rb
+++ b/lib/injectable/dependency.rb
@@ -16,6 +16,10 @@ module Injectable
     def wrap_call(the_instance)
       return the_instance unless call
 
+      if the_instance.respond_to? :call
+        raise Injectable::MethodAlreadyExistsException
+      end
+
       the_instance.tap do |instance|
         call_method = call
 

--- a/lib/injectable/method_already_exists_exception.rb
+++ b/lib/injectable/method_already_exists_exception.rb
@@ -1,0 +1,4 @@
+module Injectable
+  class MethodAlreadyExistsException < RuntimeError
+  end
+end

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -185,6 +185,36 @@ describe Injectable do
     end
   end
 
+  context 'with dependencies that have a call: option and an existing #call method' do
+    before do
+      SomeCallableRenderer = Class.new do
+        def render(arg, kwarg:)
+          "#render has been called with #{arg} and #{kwarg}"
+        end
+
+        def call(something_else)
+          "#call with #{something_else}"
+        end
+      end
+    end
+
+    subject do
+      Class.new do
+        include Injectable
+        extend Forwardable
+        dependency :some_callable_renderer, call: :render
+
+        def call
+          some_callable_renderer.call('hello', kwarg: 'world')
+        end
+      end
+    end
+
+    it 'raises an exception' do
+      expect { subject.call }.to raise_error Injectable::MethodAlreadyExistsException
+    end
+  end
+
   context 'with plural dependencies' do
     before do
       Chicharrons = Class.new

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -499,7 +499,7 @@ describe Injectable do
 
   context 'when the dependency accepts a block' do
     before do
-      class BlockPasser
+      class CallableBlockPasser
         def call
           yield
         end
@@ -510,10 +510,10 @@ describe Injectable do
       Class.new do
         include Injectable
 
-        dependency :block_passer
+        dependency :callable_block_passer
 
         def call
-          block_passer.call { "can't block this" }
+          callable_block_passer.call { "can't block this" }
         end
       end
     end
@@ -525,7 +525,7 @@ describe Injectable do
 
   context 'when the dependency accepts a block and has #call aliased' do
     before do
-      class BlockPasser
+      class RunnableBlockPasser
         def run
           yield
         end
@@ -536,10 +536,10 @@ describe Injectable do
       Class.new do
         include Injectable
 
-        dependency :block_passer, call: :run
+        dependency :runnable_block_passer, call: :run
 
         def call
-          block_passer.call { "can't block this" }
+          runnable_block_passer.call { "can't block this" }
         end
       end
     end


### PR DESCRIPTION
The work done for #7 changed how we aliased `#call` by adding it to the singleton class of the instance instead of returning a lambda with the behavior (so it can accept blocks if needed).

This had some benefits, but also could introduce some unexpected behavior if the original class already responded to `#call`.

For instance, when using `ActionCable.server` (which acts as a singleton), it would shadow the `#call` used as a Rack server to listen to clients wanting to register a WebSocket.

This work ensures the developer doesn't introduce unexpected side effects when inverting third party library dependencies.