### PR TITLE
Return method object instead of monkey patching

### DIFF
--- a/lib/injectable/dependency.rb
+++ b/lib/injectable/dependency.rb
@@ -20,13 +20,7 @@ module Injectable
         raise Injectable::MethodAlreadyExistsException
       end
 
-      the_instance.tap do |instance|
-        call_method = call
-
-        instance.define_singleton_method(:call) do |*args, &block|
-          send(call_method, *args, &block)
-        end
-      end
+      the_instance.public_method(call)
     end
 
     def build_instance(args, namespace:)

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -215,6 +215,24 @@ describe Injectable do
     end
   end
 
+  context 'with dependencies that have a call: option with a constant' do
+    subject do
+      Class.new do
+        include Injectable
+        dependency(:some_constant, call: :name) { Object }
+
+        def call
+          some_constant.call
+        end
+      end
+    end
+
+    it 'does not try to patch the dependency twice' do
+      subject.call
+      expect(subject.call).to eq 'Object'
+    end
+  end
+
   context 'with plural dependencies' do
     before do
       Chicharrons = Class.new

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -227,9 +227,16 @@ describe Injectable do
       end
     end
 
-    it 'does not try to patch the dependency twice' do
+    before do
       subject.call
+    end
+
+    it 'does not try to patch the dependency twice' do
       expect(subject.call).to eq 'Object'
+    end
+
+    it 'leaves the dependency unpatched' do
+      expect(Object).not_to respond_to(:call)
     end
   end
 


### PR DESCRIPTION
When an alternative method (not `:call`) is passed, instead of adding a new method we can return
a bound method, which will already respond to `:call` as expected.

This should solve #16 and probably there is no need to raise `Injectable::MethodAlreadyExistsException`
anymore