### PR TITLE
Use dynamic modules to allow correct `call` inheritance

### DIFF
--- a/lib/injectable.rb
+++ b/lib/injectable.rb
@@ -1,4 +1,5 @@
 require 'injectable/version'
+require 'injectable/call_facade'
 require 'injectable/class_methods'
 require 'injectable/dependencies_graph'
 require 'injectable/dependencies_proxy'

--- a/lib/injectable/call_facade.rb
+++ b/lib/injectable/call_facade.rb
@@ -1,0 +1,26 @@
+module Injectable
+  module CallFacade
+    def self.[](klass)
+      m = Module.new do
+        # Entry point of the service.
+        # Arguments for this method should be declared explicitly with '.argument'
+        # and declare this method without arguments
+        define_method :call do |args = {}|
+          if self.instance_of?(klass)
+            check_call_definition!
+            check_missing_arguments!(self.class.required_call_arguments, args)
+            variables_for!(self.class.call_arguments, args)
+          end
+
+          super()
+        end
+
+        def self.facade?
+          true
+        end
+      end
+
+      klass.const_set(:InjectableCallFacade, m)
+    end
+  end
+end

--- a/lib/injectable/class_methods.rb
+++ b/lib/injectable/class_methods.rb
@@ -9,6 +9,8 @@ module Injectable
         self.dependencies = DependenciesGraph.new(namespace: base)
         self.initialize_arguments = {}
         self.call_arguments = {}
+
+        prepend(Injectable::CallFacade[base])
       end
     end
 
@@ -17,6 +19,8 @@ module Injectable
         self.dependencies = dependencies.with_namespace(base)
         self.initialize_arguments = initialize_arguments.dup
         self.call_arguments = call_arguments.dup
+
+        prepend(Injectable::CallFacade[base])
       end
     end
 

--- a/lib/injectable/instance_methods.rb
+++ b/lib/injectable/instance_methods.rb
@@ -8,21 +8,11 @@ module Injectable
       super()
     end
 
-    # Entry point of the service.
-    # Arguments for this method should be declared explicitly with '.argument'
-    # and declare this method without arguments
-    def call(args = {})
-      check_call_definition!
-      check_missing_arguments!(self.class.required_call_arguments, args)
-      variables_for!(self.class.call_arguments, args)
-      super()
-    end
-
     private
 
     def check_call_definition!
       return if (self.class.ancestors - [Injectable::InstanceMethods]).any? do |ancestor|
-        ancestor.instance_methods(false).include?(:call)
+        ancestor.instance_methods(false).include?(:call) && !ancestor.respond_to?(:facade?)
       end
       raise NoMethodError, "A #call method with zero arity must be defined in #{self.class}"
     end

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -578,4 +578,30 @@ describe Injectable do
       expect(subject.call).to eq "can't block this"
     end
   end
+
+  context 'when subclassing' do
+    let(:service) do
+      Class.new do
+        include Injectable
+
+        argument :num, required: true
+
+        def call
+          num + 2
+        end
+      end
+    end
+
+    let(:service_subclass) do
+      Class.new(service) do
+        def call
+          super + 3
+        end
+      end
+    end
+
+    it 'respects inheritance' do
+      expect(service_subclass.call(num: 1)).to eq 6
+    end
+  end
 end


### PR DESCRIPTION
This should close #19 

With this change, the ancestors of a subclass of a service are:
```rb
puts my_service_instance.class.ancestors
# SubClass::InjectableCallFacade
# SubClass
# Injectable::InstanceMethods
# SuperClass::InjectableCallFacade
# SuperClass
# Injectable
# Object
# Kernel
# BasicObject
```

Each concrete class over Injectable gets a dynamically generated module, with a `:call` implementation that
* if the concrete class is the actual class of an object, takes the arguments as expected, and then call super with no arguments.
* otherwise, it will assume that another facade has already run, so it will _just_ call super with no arguments.

This way we have an alternating chain of methods (one in the facade and one in the concrete class) that call each other.

The dynamically generated module does not need to be assigned to a constant, but it helps when reading traces.