### PR TITLE
Prepare for Ruby 3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,15 +8,16 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        ruby: [ 2.5.x, 2.6, 2.7.x ]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby ${{ matrix.ruby }}
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: ${{ matrix.ruby }}
     - name: Build and test with Rake
       run: |
         gem install bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,30 +6,30 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (11.1.1)
-    coderay (1.1.2)
-    diff-lcs (1.3)
-    method_source (0.9.2)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    pry-byebug (3.8.0)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    diff-lcs (1.4.4)
+    method_source (1.0.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
       byebug (~> 11.0)
-      pry (~> 0.10)
-    rake (12.3.3)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.3)
+      pry (~> 0.13.0)
+    rake (13.0.3)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.1)
 
 PLATFORMS
   ruby
@@ -38,8 +38,8 @@ DEPENDENCIES
   bundler (~> 2.0)
   injectable!
   pry-byebug
-  rake (~> 12.0)
+  rake (~> 13.0)
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.1.2
+   2.2.4

--- a/injectable.gemspec
+++ b/injectable.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/injectable.gemspec
+++ b/injectable.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'pry-byebug'

--- a/lib/injectable/class_methods.rb
+++ b/lib/injectable/class_methods.rb
@@ -97,7 +97,7 @@ module Injectable
       options[:block] = block if block_given?
       options[:depends_on] = Array(options.fetch(:depends_on, []))
       options[:name] = name
-      dependencies.add(options)
+      dependencies.add(**options)
       define_method name do
         instance_variable_get("@#{name}") || dependencies_proxy.get(name)
       end

--- a/lib/injectable/dependency.rb
+++ b/lib/injectable/dependency.rb
@@ -24,7 +24,9 @@ module Injectable
     end
 
     def build_instance(args, namespace:)
-      block.nil? ? klass(namespace: namespace).new(*args) : block.call(*args)
+      return klass(namespace: namespace).new(*args) if block.nil?
+
+      block.call(*args)
     end
 
     def klass(namespace:)

--- a/spec/injectable/dependencies_graph_spec.rb
+++ b/spec/injectable/dependencies_graph_spec.rb
@@ -30,7 +30,7 @@ describe Injectable::DependenciesGraph, '#resolve' do
     before do
       allow(dependency_class).to receive(:new).with(options).and_return(dependency)
       allow(proxy_class).to receive(:new).with(graph: { name => dependency }, namespace: ns).and_return(proxy)
-      graph.add(options)
+      graph.add(**options)
     end
 
     subject { graph.proxy }


### PR DESCRIPTION
This library will spit out several warnings when running under Ruby 2.7.1. This PR is an attempt to get those warnings sorted out in the best way so we ensure nothing breaks for Ruby 3.

There's still a couple of dep warnings on the dependency.rb file I'm not sure how to solve. Trying to understand if the problem is in the method definition or on the calls to that method. You can get them by running `rspec` under Ruby 2.7.1:

```rb
Injectable::Dependency instance
  with keyword arguments
injectable/lib/injectable/dependency.rb:27: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
injectable/spec/injectable/dependency_spec.rb:43: warning: The called method `initialize' is defined here

Injectable
  with dependencies that have a with: keyword option
injectable/lib/injectable/dependency.rb:27: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
injectable/spec/injectable_spec.rb:139: warning: The called method `initialize' is defined here
    passes it to the dependency #initialize method

  with block dependencies that take dependencies
injectable/lib/injectable/dependency.rb:29: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
injectable/spec/injectable_spec.rb:453: warning: The called method `call' is defined here
```

In the meantime:

- Drops support for Ruby < 2.5
- Updates some of the gem dependencies

## Reference:

- https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
- https://stackoverflow.com/questions/59490108/the-called-method-is-defined-here

## Question

After the warnings are solved, a version bump will be in order. Should it be 2.1 or 2.0.1?