### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Unreleased
 
+### 2.1.0 - 2021-01-05
+
+* enhancements
+  * Return `method` object instead of monkey patched instance (#17)
+  * Prepare for Ruby 3.0 (#22)
+
 ### 2.0.0 - 2020-03-16
 
 * breaking changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    injectable (2.0.0)
+    injectable (2.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -355,6 +355,6 @@ Everyone interacting in the Injectable project’s codebases, issue trackers, ch
 
 - [RubiconMD](https://github.com/rubiconmd) allowed extracting this gem from its codebase and release it as open source.
 - [Durran Jordan](https://github.com/durran) allowed the usage of the gem name at rubygems.org.
-- [David Marchante](https://github.com/iovis9) brainstormed the `initialize`/`call` approach, did all code reviews and provided lots of insightful feedback and suggestions. He also wrote the inline documentation.
+- [David Marchante](https://github.com/iovis) brainstormed the `initialize`/`call` approach, did all code reviews and provided lots of insightful feedback and suggestions. He also wrote the inline documentation.
 - [Julio Antequera](https://github.com/jantequera), [Jimmi Carney](https://github.com/ayoformayo) and [Anthony Rocco](https://github.com/amrocco) had the patience to use it and report many bugs. Also most of the features in this gem came up when reviewing their usage of it. Anthony also made the effort of extracting the code from RubiconMD's codebase.
 - [Rodrigo Álvarez](https://github.com/Papipo) had the idea for the DSL and actually wrote the library.

--- a/injectable.gemspec
+++ b/injectable.gemspec
@@ -5,8 +5,8 @@ require 'injectable/version'
 Gem::Specification.new do |spec|
   spec.name          = 'injectable'
   spec.version       = Injectable::VERSION
-  spec.authors       = %w[Papipo iovis9 jantequera amrocco]
-  spec.email         = %w[dev@rubiconmd.com david.marchante@rubiconmd.com julio@rubiconmd.com anthony@rubiconmd.com]
+  spec.authors       = %w[Papipo iovis jantequera amrocco rewritten]
+  spec.email         = %w[dev@rubiconmd.com]
 
   spec.summary       = 'A library to help you build nice service objects with dependency injection.'
   spec.homepage      = 'https://github.com/rubiconmd/injectable'

--- a/lib/injectable/version.rb
+++ b/lib/injectable/version.rb
@@ -1,3 +1,3 @@
 module Injectable
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.1.0'.freeze
 end


### PR DESCRIPTION
### 2.1.0 - 2021-01-05

* enhancements
  * Return `method` object instead of monkey patched instance (#17)
  * Prepare for Ruby 3.0 (#22)