### PR TITLE
Ruby 2.7.1 warnings: AHORA SI QUE SI, CABESA

### DIFF
--- a/lib/injectable/dependency.rb
+++ b/lib/injectable/dependency.rb
@@ -26,9 +26,17 @@ module Injectable
     end
 
     def build_instance(args, kwargs, namespace:)
-      return klass(namespace: namespace).new(*args, **kwargs) if block.nil?
+      if RUBY_VERSION < '2.7'
+        args << kwargs if kwargs.any?
 
-      block.call(*args, **kwargs)
+        return klass(namespace: namespace).new(*args) if block.nil?
+
+        block.call(*args)
+      else
+        return klass(namespace: namespace).new(*args, **kwargs) if block.nil?
+
+        block.call(*args, **kwargs)
+      end
     end
 
     def klass(namespace:)

--- a/lib/injectable/dependency.rb
+++ b/lib/injectable/dependency.rb
@@ -12,7 +12,7 @@ module Injectable
     def wrap_args(args)
       args = with unless with.nil?
 
-      args_splitter(args)
+      split_args(args)
     end
 
     def wrap_call(the_instance)
@@ -51,7 +51,7 @@ module Injectable
       @camelcased ||= name.to_s.split('_').map(&:capitalize).join
     end
 
-    def args_splitter(args)
+    def split_args(args)
       args = args.is_a?(Array) ? args : [args]
 
       positional_args = []

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -191,6 +191,103 @@ describe Injectable do
     end
   end
 
+  context 'with dependencies that get hashes for both positional args and kwargs' do
+    before do
+      DepWithManyArgs = Class.new do
+        def initialize(arg1, arg2 = nil, arg3: nil, arg4: nil)
+          @args = [arg1, arg2, arg3, arg4]
+        end
+
+        def call
+          @args
+        end
+      end
+    end
+
+    context 'when all args are given' do
+      subject do
+        Class.new do
+          include Injectable
+
+          dependency :dep_with_many_args, with: [
+            {arg1_key: 'arg1_value'}, 
+            {arg2_key: 'arg2_value'}, 
+            arg3: 'arg3_value',
+            arg4: 'arg4_value'
+          ]
+
+          def call
+            dep_with_many_args.call
+          end
+        end
+      end
+
+      it 'keeps arguments separate' do
+        expect(subject.call).to eq [
+          {arg1_key: 'arg1_value'}, 
+          {arg2_key: 'arg2_value'}, 
+          'arg3_value',
+          'arg4_value'
+        ]
+      end
+    end
+
+    context 'when a positional arg is skipped' do
+      subject do
+        Class.new do
+          include Injectable
+
+          dependency :dep_with_many_args, with: [
+            {arg1_key: 'arg1_value'}, 
+            arg3: 'arg3_value',
+            arg4: 'arg4_value'
+          ]
+
+          def call
+            dep_with_many_args.call
+          end
+        end
+      end
+
+      it 'keeps arguments separate' do
+        expect(subject.call).to eq [
+          {arg1_key: 'arg1_value'}, 
+          nil, 
+          'arg3_value',
+          'arg4_value'
+        ]
+      end
+    end
+
+    context 'when kwargs are skipped' do
+      subject do
+        Class.new do
+          include Injectable
+
+          dependency :dep_with_many_args, with: [
+            {arg1_key: 'arg1_value'}, 
+            {arg2_key: 'arg2_value'}
+          ]
+
+          def call
+            dep_with_many_args.call
+          end
+        end
+      end
+
+      it 'keeps arguments separate' do
+        expect(subject.call).to eq [
+          {arg1_key: 'arg1_value'}, 
+          {arg2_key: 'arg2_value'}, 
+          nil,
+          nil
+        ]
+      end
+    end
+
+  end
+
+
   context 'with dependencies that have a call: option' do
     before do
       SomeRenderer = Class.new do

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -159,6 +159,38 @@ describe Injectable do
     end
   end
 
+  context 'with dependencies that have a with: keyword option and other with array' do
+    before do
+      DepWithBothArgs = Class.new do
+        attr_reader :somearg, :options
+        def initialize(somearg, **options)
+          @options = options
+          @somearg = somearg
+        end
+
+        def to_s
+          "#{options[:my_arg]} | #{somearg}"
+        end
+      end
+    end
+
+    subject do
+      Class.new do
+        include Injectable
+
+        dependency :dep_with_both_args, with: ['with: arg', { my_arg: 'with: kwarg' }]
+
+        def call
+          dep_with_both_args.to_s
+        end
+      end
+    end
+
+    it 'passes it to the dependency #initialize method' do
+      expect(subject.call).to eq 'with: kwarg | with: arg'
+    end
+  end
+
   context 'with dependencies that have a call: option' do
     before do
       SomeRenderer = Class.new do

--- a/spec/support/dependencies.rb
+++ b/spec/support/dependencies.rb
@@ -1,0 +1,168 @@
+DepWithNormalArg = Class.new do
+  attr_reader :somearg
+  def initialize(somearg)
+    @somearg = somearg
+  end
+end
+
+DepWithKwargs = Class.new do
+  attr_reader :somearg
+  def initialize(somearg:)
+    @somearg = somearg
+  end
+end
+
+DepWithBothArgs = Class.new do
+  attr_reader :somearg, :options
+  def initialize(somearg, **options)
+    @options = options
+    @somearg = somearg
+  end
+
+  def to_s
+    "#{options[:my_arg]} | #{somearg}"
+  end
+end
+
+DepWithManyArgs = Class.new do
+  def initialize(arg1 = nil, arg2 = nil, arg3: nil, arg4: nil)
+    @args = [arg1, arg2, arg3, arg4]
+  end
+
+  def call
+    @args
+  end
+end
+
+SomeRenderer = Class.new do
+  def render(arg, kwarg:)
+    "#render has been called with #{arg} and #{kwarg}"
+  end
+end
+
+SomeCallableRenderer = Class.new do
+  def render(arg, kwarg:)
+    "#render has been called with #{arg} and #{kwarg}"
+  end
+
+  def call(something_else)
+    "#call with #{something_else}"
+  end
+end
+
+Chicharrons = Class.new
+
+ExistingClass = Class.new do
+  def call
+    'This has been constantized!'
+  end
+end
+
+WeirdName = Class.new do
+  def call
+    'This has been constantized!'
+  end
+end
+
+InjectedDep = Class.new do
+  def call
+    'InjectedDep result'
+  end
+end
+
+InjectedClass = Class.new do
+  include Injectable
+
+  dependency :injected_dep
+
+  def call
+    "I got #{injected_dep.call}"
+  end
+end
+
+class Counter
+  def initialize
+    @count = 0
+  end
+
+  def count
+    @count += 1
+  end
+end
+
+class Somedep
+  include Injectable
+
+  dependency :counter
+
+  def call
+    "Somedep -> #{counter.count}"
+  end
+end
+
+class Anotherdep
+  include Injectable
+
+  dependency :counter
+
+  def call
+    "Anotherdep -> #{counter.count}"
+  end
+end
+
+class BlockyClass
+  include Injectable
+
+  dependency :needed do
+    'this is needed'
+  end
+
+  dependency :needer, depends_on: :needed do |needed:|
+    "I got '#{needed}'"
+  end
+
+  def call
+    needer
+  end
+end
+
+class CallableBlockPasser
+  def call
+    yield
+  end
+end
+
+class RunnableBlockPasser
+  def run
+    yield
+  end
+end
+
+class Parent
+  class Dependency
+    def call
+      'in parent'
+    end
+  end
+
+  include Injectable
+  extend Forwardable
+  dependency :dependency
+  def_delegators :dependency, :call
+end
+
+class Child < Parent
+  class Dependency
+    def call
+      'in child'
+    end
+  end
+end
+
+class Sibling < Parent
+  class Dependency
+    def call
+      'in sibling'
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses the final warnings we were getting related to Ruby 2.7 change in argument delegation.

As it is, all specs are green in both Ruby 2.6 and 2.7.1

Suggestions to beautify the `split_args` and `build_instance` are welcome