### PR TITLE
Poor Man's Type Checking in Arguments and Returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Unreleased
+## Unreleased
+
+## 3.1.0 - 2025-11-12
+
+* `argument` can now optionally take a `type` option, which will be checked against the provided value when calling the object.
 
 ## 3.0.0 - 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.0 - 2025-11-12
 
 * `argument` can now optionally take a `type` option, which will be checked against the provided value when calling the object.
+* adds optional `returns` statement to typecheck the returned type of the object
 
 ## 3.0.0 - 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `argument` can now optionally take a `type` option, which will be checked against the provided value when calling the object.
 * adds optional `returns` statement to typecheck the returned type of the object
+* Fixes simplecov setup and adds code coverage.
 
 ## 3.0.0 - 2026-04-25
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    injectable (3.0.0)
+    injectable (3.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -99,7 +99,7 @@ CHECKSUMS
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
-  injectable (3.0.0)
+  injectable (3.1.0)
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc

--- a/README.md
+++ b/README.md
@@ -339,8 +339,8 @@ validation. Examples:
 
 ```rb
 argument :user,   type: User
-argument :values, type: Array
-argument :report, type: Hash
+argument :values, type: Array, default: %i[done closed accepted rejected]
+argument :report, type: Hash, default: nil
 ```
 
 Rules:
@@ -508,7 +508,7 @@ Please consider configuring [EditorConfig](https://editorconfig.org/) on your fa
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at [injectablerb/injectable](https://github.com/injectablerb/injectable). 
+Bug reports and pull requests are welcome on GitHub at [injectablerb/injectable](https://github.com/injectablerb/injectable).
 
 ### Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,38 @@ argument :browser, default: 'Unknown'
 
 If you don't pass the `:default` option the argument will be required.
 
+### Type checking for arguments
+
+You can optionally declare a `:type` for an argument to enable runtime type
+validation. Examples:
+
+```rb
+argument :user,   type: User
+argument :values, type: Array
+argument :report, type: Hash
+```
+
+Rules:
+
+- `:type` is optional — if omitted, no type checking is performed.
+- If `:type` is provided and you also provide a `:default`, the default must
+  be either `nil` or an instance of the declared type. Otherwise an
+  ArgumentError is raised at declaration time.
+- At runtime, when `#call` is invoked, any non-nil argument value passed will
+  be validated against the declared type. If the value is not an instance of
+  the declared type, an ArgumentError is raised with a helpful message.
+
+Example error message:
+
+```text
+ArgumentError: argument user passed is a Integer, needs to be a User
+```
+
+Notes:
+
+- Passing `nil` is allowed when the default is `nil` or when you explicitly
+  pass `nil` at call time. If you'd like stricter behavior (for example,
+  forbidding nil), we can add an `allow_nil: false` option in a follow-up.
 
 ## Development
 
@@ -339,11 +371,11 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
-Please consider configuring [https://editorconfig.org/] on your favourite IDE/editor, so basic file formatting is consistent and avoids cross-platform issues. Some editors require [a plugin](https://editorconfig.org/#download), meanwhile others have it [pre-installed](https://editorconfig.org/#pre-installed).
+Please consider configuring [EditorConfig](https://editorconfig.org/) on your favourite IDE/editor, so basic file formatting is consistent and avoids cross-platform issues. Some editors require [a plugin](https://editorconfig.org/#download), meanwhile others have it [pre-installed](https://editorconfig.org/#pre-installed).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/rubiconmd/injectable. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at [rubiconmd/injectable](https://github.com/rubiconmd/injectable). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -508,7 +508,11 @@ Please consider configuring [EditorConfig](https://editorconfig.org/) on your fa
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at [rubiconmd/injectable](https://github.com/rubiconmd/injectable). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at [injectablerb/injectable](https://github.com/injectablerb/injectable). 
+
+### Code of Conduct
+
+This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -338,20 +338,17 @@ You can optionally declare a `:type` for an argument to enable runtime type
 validation. Examples:
 
 ```rb
-argument :user,   type: User
-argument :values, type: Array, default: %i[done closed accepted rejected]
 argument :report, type: Hash, default: nil
+argument :values, type: Array, default: %i[done closed accepted rejected]
+argument :author, type: [User, Admin]
 ```
 
 Rules:
 
 - `:type` is optional — if omitted, no type checking is performed.
-- If `:type` is provided and you also provide a `:default`, the default must
-  be either `nil` or an instance of the declared type. Otherwise an
-  ArgumentError is raised at declaration time.
-- At runtime, when `#call` is invoked, any non-nil argument value passed will
-  be validated against the declared type. If the value is not an instance of
-  the declared type, an ArgumentError is raised with a helpful message.
+- If `:type` is provided and you also provide a `:default`, the default must be either `nil` or an instance of the declared type. Otherwise an ArgumentError is raised at declaration time.
+- `:type` can be an array of classes, as in `[Array, Hash]`. If provided, the `:default` needs to be `nil` or an instance of any of the classes in the array.
+- At runtime, when `#call` is invoked, any non-nil argument value passed will be validated against the declared type. If the value is not an instance of the declared type, an ArgumentError is raised with a helpful message.
 
 Example error message:
 
@@ -361,14 +358,11 @@ ArgumentError: argument user passed is a Integer, needs to be a User
 
 Notes:
 
-- Passing `nil` is allowed when the default is `nil` or when you explicitly
-  pass `nil` at call time. If you'd like stricter behavior (for example,
-  forbidding nil), we can add an `allow_nil: false` option in a follow-up.
+- Passing `nil` is allowed when the default is `nil` or when you explicitly pass `nil` at call time. If you'd like stricter behavior (for example, forbidding nil), we can add an `allow_nil: false` option in a follow-up.
 
 ## Return type checking
 
-You can declare the expected return type of a service with the `returns`
-macro. This enables runtime validation of the value returned by `#call`.
+You can declare the expected return type of a service with the `returns` macro. This enables runtime validation of the value returned by `#call`.
 
 Example:
 
@@ -388,8 +382,7 @@ end
 Behavior:
 
 - If `nullable: false` and the service returns `nil`, an ArgumentError is raised.
-- If the service returns a non-nil value that is not an instance of the declared
-  type, an ArgumentError is raised.
+- If the service returns a non-nil value that is not an instance of the declared type, an ArgumentError is raised.
 - If `nullable: true`, `nil` is accepted as a valid return value.
 
 Example error messages:

--- a/lib/injectable.rb
+++ b/lib/injectable.rb
@@ -6,6 +6,8 @@ require 'injectable/dependency'
 require 'injectable/instance_methods'
 require 'injectable/missing_dependencies_exception'
 require 'injectable/method_already_exists_exception'
+require 'injectable/validators/argument_declaration'
+require 'injectable/validators/argument_type'
 
 # Convert your class into an injectable service
 #

--- a/lib/injectable.rb
+++ b/lib/injectable.rb
@@ -8,6 +8,9 @@ require 'injectable/missing_dependencies_exception'
 require 'injectable/method_already_exists_exception'
 require 'injectable/validators/argument_declaration'
 require 'injectable/validators/argument_type'
+require 'injectable/validators/collection_returns'
+require 'injectable/validators/single_returns'
+require 'injectable/validators/returns'
 
 # Convert your class into an injectable service
 #

--- a/lib/injectable/class_methods.rb
+++ b/lib/injectable/class_methods.rb
@@ -195,10 +195,9 @@ module Injectable
       raise(ArgumentError, ':of for returns must be a Class or Module') unless element_class.is_a?(Module)
       raise(ArgumentError, ':collection for returns must be a Class or Module') unless collection_class.is_a?(Module)
 
-      valid_collection = collection_class.include?(Enumerable) # check method_defined?(:each) instead?
-      unless valid_collection
+      unless collection_class.instance_methods.include?(:each)
         raise(ArgumentError,
-              "#{collection_class} is not a collection-like class (must include Enumerable) when specifying :of")
+              "#{collection_class} is not a collection-like class (must respond to :each) when specifying :of")
       end
 
       { kind: :collection, collection: collection_class, elem: element_class }

--- a/lib/injectable/class_methods.rb
+++ b/lib/injectable/class_methods.rb
@@ -4,7 +4,8 @@ module Injectable
       base.class_eval do
         simple_class_attribute :dependencies,
                                :call_arguments,
-                               :initialize_arguments
+                               :initialize_arguments,
+                               :return_spec
 
         self.dependencies = DependenciesGraph.new(namespace: base)
         self.initialize_arguments = {}
@@ -141,6 +142,28 @@ module Injectable
       attr_accessor name
     end
 
+    # Declare the expected return type for the service's `#call` method.
+    # Example:
+    #   returns User, nullable: false
+    # If a return type is declared, the value returned by `#call` will be
+    # validated at runtime. If the value is nil and `allow_nil` is false an
+    # ArgumentError will be raised. If the value is non-nil and not an
+    # instance of the declared type, an ArgumentError will be raised.
+    # New returns API
+    # Single object:
+    #   returns(User, nullable: true/false)
+    # Collection:
+    #   returns(CollectionClass, of: User, nullable: true/false, allow_nils: true/false)
+    def returns(type, of: nil, nullable: false, allow_nils: false)
+      spec = { nullable: nullable, allow_nils: allow_nils }
+
+      self.return_spec = if of.nil?
+                           spec.merge(initialize_single_return(type))
+                         else
+                           spec.merge(initialize_collection_return(type, of))
+                         end
+    end
+
     def initialize_with(name, options = {})
       initialize_arguments[name] = options
       attr_accessor name
@@ -160,6 +183,27 @@ module Injectable
 
     def find_required_arguments(hash)
       hash.reject { |_arg, options| options.key?(:default) }.keys
+    end
+
+    def initialize_single_return(type)
+      raise(ArgumentError, ':type for returns must be a Class or Module') unless type.is_a?(Module)
+
+      { kind: :single, type: type }
+    end
+
+    def initialize_collection_return(collection_class, element_class)
+      raise(ArgumentError, ':of for returns must be a Class or Module') unless element_class.is_a?(Module)
+
+      valid_collection = collection_class.is_a?(Class) || collection_class.is_a?(Module)
+      raise(ArgumentError, ':collection for returns must be a Class or Module') unless valid_collection
+
+      valid_collection = collection_class.include?(Enumerable) # check method_defined?(:each) instead?
+      unless valid_collection
+        raise(ArgumentError,
+              "#{collection_class} is not a collection-like class (must include Enumerable) when specifying :of")
+      end
+
+      { kind: :collection, collection: collection_class, elem: element_class }
     end
   end
 end

--- a/lib/injectable/class_methods.rb
+++ b/lib/injectable/class_methods.rb
@@ -195,7 +195,7 @@ module Injectable
       raise(ArgumentError, ':of for returns must be a Class or Module') unless element_class.is_a?(Module)
       raise(ArgumentError, ':collection for returns must be a Class or Module') unless collection_class.is_a?(Module)
 
-      unless collection_class.instance_methods.include?(:each)
+      unless collection_class.method_defined?(:each)
         raise(ArgumentError,
               "#{collection_class} is not a collection-like class (must respond to :each) when specifying :of")
       end

--- a/lib/injectable/class_methods.rb
+++ b/lib/injectable/class_methods.rb
@@ -200,7 +200,7 @@ module Injectable
               "#{collection_class} is not a collection-like class (must respond to :each) when specifying :of")
       end
 
-      { kind: :collection, collection: collection_class, elem: element_class }
+      { kind: :collection, collection_type: collection_class, element_type: element_class }
     end
   end
 end

--- a/lib/injectable/class_methods.rb
+++ b/lib/injectable/class_methods.rb
@@ -120,6 +120,8 @@ module Injectable
     # ```
     #
     # Every argument is required unless given an optional default value
+    # Option :type can be provided to enforce runtime type checking when the
+    # service is called. Example: `argument :user, type: User`.
     # @param name Name of the argument
     # @option options :default The default value of the argument
     # @example
@@ -131,8 +133,10 @@ module Injectable
     #   argument :team_id, default: 1
     #     # => def call(team_id: 1)
     #     # =>   @team_id = team_id
-    #     # => end
+    #     # => end)
     def argument(name, options = {})
+      Injectable::Validators::ArgumentDeclaration.validate!(name, options[:type], options[:default])
+
       call_arguments[name] = options
       attr_accessor name
     end

--- a/lib/injectable/class_methods.rb
+++ b/lib/injectable/class_methods.rb
@@ -193,9 +193,7 @@ module Injectable
 
     def initialize_collection_return(collection_class, element_class)
       raise(ArgumentError, ':of for returns must be a Class or Module') unless element_class.is_a?(Module)
-
-      valid_collection = collection_class.is_a?(Class) || collection_class.is_a?(Module)
-      raise(ArgumentError, ':collection for returns must be a Class or Module') unless valid_collection
+      raise(ArgumentError, ':collection for returns must be a Class or Module') unless collection_class.is_a?(Module)
 
       valid_collection = collection_class.include?(Enumerable) # check method_defined?(:each) instead?
       unless valid_collection

--- a/lib/injectable/instance_methods.rb
+++ b/lib/injectable/instance_methods.rb
@@ -15,7 +15,11 @@ module Injectable
       check_call_definition!
       check_missing_arguments!(self.class.required_call_arguments, args)
       variables_for!(self.class.call_arguments, args)
-      super()
+      result = super()
+
+      Injectable::Validators::Returns.validate!(self.class.return_spec, result)
+
+      result
     end
 
     private

--- a/lib/injectable/instance_methods.rb
+++ b/lib/injectable/instance_methods.rb
@@ -37,7 +37,11 @@ module Injectable
 
     def variables_for!(subject, args)
       subject.each do |arg, options|
-        instance_variable_set("@#{arg}", args.fetch(arg) { options[:default] })
+        value = args.fetch(arg) { options[:default] }
+
+        Injectable::Validators::ArgumentType.validate!(arg, options[:type], value)
+
+        instance_variable_set("@#{arg}", value)
       end
     end
 

--- a/lib/injectable/validators/argument_declaration.rb
+++ b/lib/injectable/validators/argument_declaration.rb
@@ -15,7 +15,7 @@ module Injectable
           raise(ArgumentError, wrong_type_message(name)) unless type.is_a?(Module)
           return unless default
 
-          raise ArgumentError, bad_default_type(name, default.class, type) unless default.is_a?(type)
+          raise ArgumentError, bad_default_type_message(name, default.class, type) unless default.is_a?(type)
         end
 
         private
@@ -24,7 +24,7 @@ module Injectable
           ":type for argument #{name} must be a Class or Module"
         end
 
-        def bad_default_type(name, default_class, type)
+        def bad_default_type_message(name, default_class, type)
           "default for argument #{name} is a #{default_class}, needs to be a #{type}"
         end
       end

--- a/lib/injectable/validators/argument_declaration.rb
+++ b/lib/injectable/validators/argument_declaration.rb
@@ -1,0 +1,33 @@
+module Injectable
+  module Validators
+    # Validate argument declaration options and normalize them.
+    # @name => name of the argument
+    # @type => declared class for the argument
+    # @default => declaration of default value for the argument
+    #
+    # @return nil if all is good
+    # raises ArgumentError when problems are found
+    class ArgumentDeclaration
+      class << self
+        def validate!(name, type = nil, default = nil)
+          return unless type
+
+          raise(ArgumentError, wrong_type_message(name)) unless type.is_a?(Module)
+          return unless default
+
+          raise ArgumentError, bad_default_type(name, default.class, type) unless default.is_a?(type)
+        end
+
+        private
+
+        def wrong_type_message(name)
+          ":type for argument #{name} must be a Class or Module"
+        end
+
+        def bad_default_type(name, default_class, type)
+          "default for argument #{name} is a #{default_class}, needs to be a #{type}"
+        end
+      end
+    end
+  end
+end

--- a/lib/injectable/validators/argument_declaration.rb
+++ b/lib/injectable/validators/argument_declaration.rb
@@ -32,7 +32,7 @@ module Injectable
         def validate_array(name, types, default)
           raise ArgumentError, empty_types_array_message(name) if types.empty?
 
-          array_of_modules = types.all? { |t| t.is_a?(Module) }
+          array_of_modules = types.all?(Module)
           raise ArgumentError, wrong_types_in_array_message(name) unless array_of_modules
           return if default.nil?
 

--- a/lib/injectable/validators/argument_declaration.rb
+++ b/lib/injectable/validators/argument_declaration.rb
@@ -2,7 +2,7 @@ module Injectable
   module Validators
     # Validate argument declaration options and normalize them.
     # @name => name of the argument
-    # @type => declared class for the argument
+    # @type => declared class or Array of classes for the argument
     # @default => declaration of default value for the argument
     #
     # @return nil if all is good
@@ -10,22 +10,56 @@ module Injectable
     class ArgumentDeclaration
       class << self
         def validate!(name, type = nil, default = nil)
-          return unless type
+          return if type.nil?
 
-          raise(ArgumentError, wrong_type_message(name)) unless type.is_a?(Module)
-          return unless default
-
-          raise ArgumentError, bad_default_type_message(name, default.class, type) unless default.is_a?(type)
+          case type
+          when Module then validate_class(name, type, default)
+          when Array then validate_array(name, type, default)
+          else
+            raise(ArgumentError, wrong_type_message(name))
+          end
         end
 
         private
 
+        def validate_class(name, type, default)
+          return if default.nil?
+          return if default.is_a?(type)
+
+          raise ArgumentError, bad_default_type_message(name, default.class, type)
+        end
+
+        def validate_array(name, types, default)
+          raise ArgumentError, empty_types_array_message(name) if types.empty?
+
+          array_of_modules = types.all? { |t| t.is_a?(Module) }
+          raise ArgumentError, wrong_types_in_array_message(name) unless array_of_modules
+          return if default.nil?
+
+          default_in_array = types.any? { |t| default.is_a?(t) }
+          return if default_in_array
+
+          raise ArgumentError, bad_default_type_in_array_message(name, default.class, types)
+        end
+
         def wrong_type_message(name)
-          ":type for argument #{name} must be a Class or Module"
+          ":type for argument #{name} must be a Class, a Module or an Array of Classes or Modules"
         end
 
         def bad_default_type_message(name, default_class, type)
           "default for argument #{name} is a #{default_class}, needs to be a #{type}"
+        end
+
+        def empty_types_array_message(name)
+          ":type for argument #{name} can't be an empty Array"
+        end
+
+        def wrong_types_in_array_message(name)
+          ":type for argument #{name} is defined as an Array, but its contents are not all Classes or Modules"
+        end
+
+        def bad_default_type_in_array_message(name, default_class, types)
+          "default for argument #{name} is a #{default_class}, needs to be #{types.join(' or ')}"
         end
       end
     end

--- a/lib/injectable/validators/argument_type.rb
+++ b/lib/injectable/validators/argument_type.rb
@@ -1,0 +1,26 @@
+module Injectable
+  module Validators
+    # Validate the value of the argument matches the provided type
+    # @name => of the argument
+    # @type => expected class of the value
+    # @value => the object of validation
+    #
+    # @returns nil if all is right
+    # raises RuntimeError when problems are found
+    class ArgumentType
+      class << self
+        def validate!(name, type = nil, value = nil)
+          return unless type
+          return unless value
+          raise bad_type_message(name, value.class, type).to_s unless value.is_a?(type)
+        end
+
+        private
+
+        def bad_type_message(name, value_class, expected)
+          "argument #{name} passed is a #{value_class}, needs to be a #{expected}"
+        end
+      end
+    end
+  end
+end

--- a/lib/injectable/validators/argument_type.rb
+++ b/lib/injectable/validators/argument_type.rb
@@ -2,7 +2,7 @@ module Injectable
   module Validators
     # Validate the value of the argument matches the provided type
     # @name => of the argument
-    # @type => expected class of the value
+    # @type => expected class of the value, or Array of available classes for the value
     # @value => the object of validation
     #
     # @returns nil if all is right
@@ -10,15 +10,41 @@ module Injectable
     class ArgumentType
       class << self
         def validate!(name, type = nil, value = nil)
-          return unless type
-          return unless value
-          raise bad_type_message(name, value.class, type).to_s unless value.is_a?(type)
+          return if type.nil?
+          return if value.nil?
+
+          case type
+          when Module then validate_type(name, type, value)
+          when Array then validate_type_in_array(name, type, value)
+          else
+            raise wrong_type_message(name)
+          end
         end
 
         private
 
+        def validate_type(name, type, value)
+          return if value.is_a?(type)
+
+          raise bad_type_message(name, value.class, type)
+        end
+
+        def validate_type_in_array(name, types, value)
+          return if types.any? { |t| value.is_a?(t) }
+
+          raise bad_type_array_message(name, value.class, types)
+        end
+
         def bad_type_message(name, value_class, expected)
           "argument #{name} passed is a #{value_class}, needs to be a #{expected}"
+        end
+
+        def wrong_type_message(name)
+          ":type for argument #{name} must be a Class, a Module or an Array of Classes or Modules"
+        end
+
+        def bad_type_array_message(name, value_class, expected)
+          "argument #{name} passed is a #{value_class}, needs to be a #{expected.join(' or ')}"
         end
       end
     end

--- a/lib/injectable/validators/collection_returns.rb
+++ b/lib/injectable/validators/collection_returns.rb
@@ -1,0 +1,42 @@
+module Injectable
+  module Validators
+    # Enforces collection type, contents types, and nils are respected
+    # @return nil if all is right
+    # raises RunTimeError if problems are found
+    class CollectionReturns
+      class << self
+        def validate!(collection_type, element_type, nullable, allow_nils, result)
+          if result.nil?
+            raise(non_nullable_collection(collection_type, element_type).to_s) unless nullable
+          elsif !result.is_a?(collection_type)
+            raise(bad_collection_type(result.class, collection_type, element_type).to_s)
+          else
+            result.each { |element| validate(element, allow_nils, element_type) }
+          end
+        end
+
+        private
+
+        def validate(element, allow_nils, element_type)
+          if element.nil?
+            raise('collection contains nil but allow_nils is false') unless allow_nils
+          elsif !element.is_a?(element_type)
+            raise(bad_element_type(element.class, element_type).to_s)
+          end
+        end
+
+        def non_nullable_collection(collection_type, element_type)
+          "return value is nil, expected a #{collection_type} of #{element_type}"
+        end
+
+        def bad_collection_type(result_class, collection_type, element_type)
+          "return value is a #{result_class}, needs to be a #{collection_type} of #{element_type}"
+        end
+
+        def bad_element_type(found, expected)
+          "return collection contains a #{found}, needs elements of #{expected}"
+        end
+      end
+    end
+  end
+end

--- a/lib/injectable/validators/collection_returns.rb
+++ b/lib/injectable/validators/collection_returns.rb
@@ -7,21 +7,21 @@ module Injectable
       class << self
         def validate!(collection_type, element_type, nullable, allow_nils, result)
           if result.nil?
-            raise(non_nullable_collection(collection_type, element_type).to_s) unless nullable
+            raise(non_nullable_collection(collection_type, element_type)) unless nullable
           elsif !result.is_a?(collection_type)
-            raise(bad_collection_type(result.class, collection_type, element_type).to_s)
+            raise(bad_collection_type(result.class, collection_type, element_type))
           else
-            result.each { |element| validate(element, allow_nils, element_type) }
+            result.each_with_index { |e, i| validate(e, allow_nils, element_type, i) }
           end
         end
 
         private
 
-        def validate(element, allow_nils, element_type)
+        def validate(element, allow_nils, element_type, index)
           if element.nil?
-            raise('collection contains nil but allow_nils is false') unless allow_nils
+            raise("collection contains nil at position #{index} but allow_nils is false") unless allow_nils
           elsif !element.is_a?(element_type)
-            raise(bad_element_type(element.class, element_type).to_s)
+            raise(bad_element_type(element.class, element_type, index))
           end
         end
 
@@ -33,8 +33,8 @@ module Injectable
           "return value is a #{result_class}, needs to be a #{collection_type} of #{element_type}"
         end
 
-        def bad_element_type(found, expected)
-          "return collection contains a #{found}, needs elements of #{expected}"
+        def bad_element_type(found, expected, index)
+          "return collection contains a #{found} at position #{index}, needs elements of #{expected}"
         end
       end
     end

--- a/lib/injectable/validators/returns.rb
+++ b/lib/injectable/validators/returns.rb
@@ -1,0 +1,27 @@
+module Injectable
+  module Validators
+    # Given a return specification, validates according to its kind
+    # @returns nil if all is right
+    # raises RuntimeError in case of problems
+    class Returns
+      class << self
+        def validate!(spec, result)
+          return unless spec
+
+          kind = spec[:kind]
+
+          case kind
+          when :single
+            Injectable::Validators::SingleReturns.validate!(*spec.values_at(:type, :nullable), result)
+          when :collection
+            Injectable::Validators::CollectionReturns.validate!(
+              *spec.values_at(:collection, :elem, :nullable, :allow_nils), result
+            )
+          else
+            raise("unknown return spec kind: #{kind}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/injectable/validators/returns.rb
+++ b/lib/injectable/validators/returns.rb
@@ -15,7 +15,7 @@ module Injectable
             Injectable::Validators::SingleReturns.validate!(*spec.values_at(:type, :nullable), result)
           when :collection
             Injectable::Validators::CollectionReturns.validate!(
-              *spec.values_at(:collection, :elem, :nullable, :allow_nils), result
+              *spec.values_at(:collection_type, :element_type, :nullable, :allow_nils), result
             )
           else
             raise("unknown return spec kind: #{kind}")

--- a/lib/injectable/validators/single_returns.rb
+++ b/lib/injectable/validators/single_returns.rb
@@ -1,0 +1,26 @@
+module Injectable
+  module Validators
+    # Enforces returned type and nullability
+    class SingleReturns
+      class << self
+        def validate!(type, nullable, result)
+          if result.nil?
+            raise(non_nullable_error_message(type).to_s) unless nullable
+          elsif !result.is_a?(type)
+            raise(bad_type(type, result.class).to_s)
+          end
+        end
+
+        private
+
+        def non_nullable_error_message(expected_type)
+          "return value is nil, expected #{expected_type}"
+        end
+
+        def bad_type(expected_type, result_class)
+          "return value is a #{result_class}, needs to be a #{expected_type}"
+        end
+      end
+    end
+  end
+end

--- a/lib/injectable/validators/single_returns.rb
+++ b/lib/injectable/validators/single_returns.rb
@@ -5,9 +5,9 @@ module Injectable
       class << self
         def validate!(type, nullable, result)
           if result.nil?
-            raise(non_nullable_error_message(type).to_s) unless nullable
+            raise(non_nullable_error_message(type)) unless nullable
           elsif !result.is_a?(type)
-            raise(bad_type(type, result.class).to_s)
+            raise(bad_type(type, result.class))
           end
         end
 

--- a/lib/injectable/version.rb
+++ b/lib/injectable/version.rb
@@ -1,3 +1,3 @@
 module Injectable
-  VERSION = '3.0.0'.freeze
+  VERSION = '3.1.0'.freeze
 end

--- a/spec/injectable/validators/argument_declaration_spec.rb
+++ b/spec/injectable/validators/argument_declaration_spec.rb
@@ -1,0 +1,38 @@
+describe Injectable::Validators::ArgumentDeclaration do
+  describe '.validate!' do
+    subject(:validate!) { described_class.validate!(name, type, default) }
+
+    let(:name) { :foo }
+    let(:default) { 1 }
+    let(:type) { nil }
+
+    context 'when type is not provided' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when type is not a class or module' do
+      let(:default) { nil }
+      let(:type) { 123 }
+
+      it 'raises an error' do
+        expect { validate! }.to raise_error(ArgumentError, /:type for argument foo must be a Class or Module/)
+      end
+    end
+
+    context 'when type and default do not match' do
+      let(:type) { String }
+
+      it 'raises an error' do
+        expect do
+          validate!
+        end.to raise_error(ArgumentError, /default for argument foo is a Integer, needs to be a String/)
+      end
+    end
+
+    context 'when type and default match' do
+      let(:type) { Integer }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/injectable/validators/argument_declaration_spec.rb
+++ b/spec/injectable/validators/argument_declaration_spec.rb
@@ -10,12 +10,39 @@ describe Injectable::Validators::ArgumentDeclaration do
       it { is_expected.to be_nil }
     end
 
-    context 'when type is not a class or module' do
+    context 'when type is not a class, module, or array of them' do
       let(:default) { nil }
       let(:type) { 123 }
 
       it 'raises an error' do
-        expect { validate! }.to raise_error(ArgumentError, /:type for argument foo must be a Class or Module/)
+        expect do
+          validate!
+        end.to raise_error(ArgumentError, /:type for argument foo must be a Class, a Module or an Array/)
+      end
+    end
+
+    context 'when type is an Array of Classes/Modules and default matches one' do
+      let(:type) { [String, Symbol] }
+      let(:default) { :bar }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when type is an Array and default is nil' do
+      let(:type) { [String, Symbol] }
+      let(:default) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when type is an Array and default does not match any' do
+      let(:type) { [String, Symbol] }
+      let(:default) { 1 }
+
+      it 'raises an error' do
+        expect do
+          validate!
+        end.to raise_error(ArgumentError, /default for argument foo is a Integer, needs to be String or Symbol/)
       end
     end
 

--- a/spec/injectable/validators/argument_type_spec.rb
+++ b/spec/injectable/validators/argument_type_spec.rb
@@ -1,0 +1,20 @@
+describe Injectable::Validators::ArgumentType do
+  describe '.validate!' do
+    it 'allows no type being passed' do
+      expect { described_class.validate!(:name, nil, 'hello') }.not_to raise_error
+    end
+
+    it 'accepts a value of the declared type' do
+      expect { described_class.validate!(:name, String, 'hello') }.not_to raise_error
+    end
+
+    it 'allows nil values even when a type is declared' do
+      expect { described_class.validate!(:count, Integer, nil) }.not_to raise_error
+    end
+
+    it 'raises ArgumentError with helpful message when type mismatches' do
+      expect { described_class.validate!(:items, Array, 123) }
+        .to raise_error(RuntimeError, /argument items passed is a Integer, needs to be a Array/)
+    end
+  end
+end

--- a/spec/injectable/validators/argument_type_spec.rb
+++ b/spec/injectable/validators/argument_type_spec.rb
@@ -16,5 +16,24 @@ describe Injectable::Validators::ArgumentType do
       expect { described_class.validate!(:items, Array, 123) }
         .to raise_error(RuntimeError, /argument items passed is a Integer, needs to be a Array/)
     end
+
+    context 'when type is not a class, module, or array of them' do
+      let(:type) { 123 }
+
+      it 'raises an error' do
+        expect do
+          described_class.validate!(:foo, type, 0)
+        end.to raise_error(RuntimeError,
+                           /:type for argument foo must be a Class, a Module or an Array of Classes or Modules/)
+      end
+    end
+
+    context 'when type is an Array of Classes/Modules' do
+      let(:type) { [String, Symbol] }
+
+      it 'accepts the array as a valid union type' do
+        expect { described_class.validate!(:foo, type, 'jarl') }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/injectable/validators/collection_returns_spec.rb
+++ b/spec/injectable/validators/collection_returns_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'injectable/validators/collection_returns'
+
+describe Injectable::Validators::CollectionReturns do
+  describe '.validate!' do
+    let(:collection_type) { Array }
+    let(:element_type) { Integer }
+    let(:nullable_collection) { false }
+    let(:allow_nil_elements) { false }
+    let(:value) { [1, 2, 3] }
+
+    it 'accepts array of correct elements' do
+      expect do
+        described_class.validate!(collection_type, element_type, nullable_collection, allow_nil_elements, value)
+      end.not_to raise_error
+    end
+
+    it 'raises when array contains wrong element type' do
+      expect do
+        described_class.validate!(collection_type, element_type, nullable_collection, allow_nil_elements, [1, 'a'])
+      end.to raise_error(RuntimeError, /return collection contains a String, needs elements of Integer/)
+    end
+
+    it 'raises when nil and not nullable' do
+      expect do
+        described_class.validate!(collection_type, element_type, nullable_collection, allow_nil_elements, nil)
+      end.to raise_error(RuntimeError, /return value is nil, expected a Array of Integer/)
+    end
+
+    it 'accepts nil when nullable' do
+      expect do
+        described_class.validate!(collection_type, element_type, true, allow_nil_elements, nil)
+      end.not_to raise_error
+    end
+
+    it 'raises if collection has nil and allow_nils false' do
+      expect do
+        described_class.validate!(collection_type, element_type, nullable_collection, allow_nil_elements, [1, nil])
+      end.to raise_error(RuntimeError, /collection contains nil but allow_nils is false/)
+    end
+
+    it 'accepts nil elements when allow_nils true' do
+      expect do
+        described_class.validate!(collection_type, element_type, nullable_collection, true, [1, nil])
+      end.not_to raise_error
+    end
+
+    it 'raises when returned object is not Enumerable or collection class' do
+      expect do
+        described_class.validate!(collection_type, element_type, nullable_collection, allow_nil_elements, 123)
+      end.to raise_error(RuntimeError, /needs to be a Array of Integer/)
+    end
+  end
+end

--- a/spec/injectable/validators/collection_returns_spec.rb
+++ b/spec/injectable/validators/collection_returns_spec.rb
@@ -18,7 +18,7 @@ describe Injectable::Validators::CollectionReturns do
     it 'raises when array contains wrong element type' do
       expect do
         described_class.validate!(collection_type, element_type, nullable_collection, allow_nil_elements, [1, 'a'])
-      end.to raise_error(RuntimeError, /return collection contains a String, needs elements of Integer/)
+      end.to raise_error(RuntimeError, /return collection contains a String at position 1, needs elements of Integer/)
     end
 
     it 'raises when nil and not nullable' do
@@ -36,7 +36,7 @@ describe Injectable::Validators::CollectionReturns do
     it 'raises if collection has nil and allow_nils false' do
       expect do
         described_class.validate!(collection_type, element_type, nullable_collection, allow_nil_elements, [1, nil])
-      end.to raise_error(RuntimeError, /collection contains nil but allow_nils is false/)
+      end.to raise_error(RuntimeError, /collection contains nil at position 1 but allow_nils is false/)
     end
 
     it 'accepts nil elements when allow_nils true' do

--- a/spec/injectable/validators/single_returns_spec.rb
+++ b/spec/injectable/validators/single_returns_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'injectable/validators/single_returns'
+
+describe Injectable::Validators::SingleReturns do
+  describe '.validate!' do
+    let(:expected_type) { String }
+    let(:nullable) { false }
+    let(:value) { 'hello' }
+
+    it 'accepts correct type' do
+      expect { described_class.validate!(expected_type, nullable, value) }.not_to raise_error
+    end
+
+    it 'raises for wrong type' do
+      expect do
+        described_class.validate!(expected_type, nullable, 123)
+      end.to raise_error(RuntimeError, /needs to be a String/)
+    end
+
+    it 'raises for nil when not nullable' do
+      expect do
+        described_class.validate!(expected_type, nullable, nil)
+      end.to raise_error(RuntimeError, /return value is nil, expected String/)
+    end
+
+    it 'accepts nil when nullable' do
+      expect { described_class.validate!(expected_type, true, nil) }.not_to raise_error
+    end
+  end
+end

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -809,7 +809,7 @@ describe Injectable do
           def each(&block)
             return enum_for(:each) unless block_given?
 
-            @values.each(&block)
+            @values.each(&block) # rubocop:disable RSpec/InstanceVariable
           end
         end
 

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -476,7 +476,7 @@ describe Injectable do
         expect { TypedService.call(user: nil) }.not_to raise_error
       end
 
-      it 'raises ArgumentError when wrong type is passed' do
+      it 'raises RuntimeError when wrong type is passed' do
         expect { StrictService.call(values: 123) }.to raise_error(RuntimeError)
       end
 
@@ -484,6 +484,58 @@ describe Injectable do
         expect do
           bad_service
         end.to raise_error(ArgumentError, /default for argument report is a Array, needs to be a Hash/)
+      end
+
+      context 'when passing an array of allowed types' do
+        before do
+          class ArrayTypedClass
+            include Injectable
+
+            argument :mode, type: [String, Symbol], default: :auto
+
+            def call
+              mode
+            end
+          end
+        end
+
+        let(:bad_array_typed_class) do
+          class BadArrayTypedClass
+            include Injectable
+
+            argument :mode, type: [String, Symbol], default: 123
+
+            def call
+              mode
+            end
+          end
+        end
+
+        it 'accepts the declared default that matches one of the union types' do
+          expect(ArrayTypedClass.call).to eq(:auto)
+        end
+
+        it 'allows passing a value matching one value of the union types' do
+          expect(ArrayTypedClass.new.call(mode: 'manual')).to eq('manual')
+        end
+
+        it 'allows passing a value matching one of the union types' do
+          expect(ArrayTypedClass.new.call(mode: :manual)).to eq(:manual)
+        end
+
+        it 'raises on runtime when passed a value not matching any union type' do
+          expect do
+            ArrayTypedClass.call(mode: 123)
+          end.to raise_error(RuntimeError,
+                             /argument mode passed is a Integer, needs to be a String or Symbol/)
+        end
+
+        it 'raises exception when the declaration is wrong' do
+          expect do
+            bad_array_typed_class
+          end.to raise_error(ArgumentError,
+                             /default for argument mode is a Integer, needs to be String or Symbol/)
+        end
       end
     end
   end

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -485,57 +485,57 @@ describe Injectable do
           bad_service
         end.to raise_error(ArgumentError, /default for argument report is a Array, needs to be a Hash/)
       end
+    end
 
-      context 'when passing an array of allowed types' do
-        before do
-          class ArrayTypedClass
-            include Injectable
+    describe 'argument type checking over an an array of allowed types' do
+      before do
+        class ArrayTypedClass
+          include Injectable
 
-            argument :mode, type: [String, Symbol], default: :auto
+          argument :mode, type: [String, Symbol], default: :auto
 
-            def call
-              mode
-            end
+          def call
+            mode
           end
         end
+      end
 
-        let(:bad_array_typed_class) do
-          class BadArrayTypedClass
-            include Injectable
+      let(:bad_array_typed_class) do
+        class BadArrayTypedClass
+          include Injectable
 
-            argument :mode, type: [String, Symbol], default: 123
+          argument :mode, type: [String, Symbol], default: 123
 
-            def call
-              mode
-            end
+          def call
+            mode
           end
         end
+      end
 
-        it 'accepts the declared default that matches one of the union types' do
-          expect(ArrayTypedClass.call).to eq(:auto)
-        end
+      it 'accepts the declared default that matches one of the union types' do
+        expect(ArrayTypedClass.call).to eq(:auto)
+      end
 
-        it 'allows passing a value matching one value of the union types' do
-          expect(ArrayTypedClass.new.call(mode: 'manual')).to eq('manual')
-        end
+      it 'allows passing a value matching one value of the union types' do
+        expect(ArrayTypedClass.new.call(mode: 'manual')).to eq('manual')
+      end
 
-        it 'allows passing a value matching one of the union types' do
-          expect(ArrayTypedClass.new.call(mode: :manual)).to eq(:manual)
-        end
+      it 'allows passing a value matching one of the union types' do
+        expect(ArrayTypedClass.new.call(mode: :manual)).to eq(:manual)
+      end
 
-        it 'raises on runtime when passed a value not matching any union type' do
-          expect do
-            ArrayTypedClass.call(mode: 123)
-          end.to raise_error(RuntimeError,
-                             /argument mode passed is a Integer, needs to be a String or Symbol/)
-        end
+      it 'raises on runtime when passed a value not matching any union type' do
+        expect do
+          ArrayTypedClass.call(mode: 123)
+        end.to raise_error(RuntimeError,
+                           /argument mode passed is a Integer, needs to be a String or Symbol/)
+      end
 
-        it 'raises exception when the declaration is wrong' do
-          expect do
-            bad_array_typed_class
-          end.to raise_error(ArgumentError,
-                             /default for argument mode is a Integer, needs to be String or Symbol/)
-        end
+      it 'raises exception when the declaration is wrong' do
+        expect do
+          bad_array_typed_class
+        end.to raise_error(ArgumentError,
+                           /default for argument mode is a Integer, needs to be String or Symbol/)
       end
     end
   end

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -801,8 +801,14 @@ describe Injectable do
         class MyCollection
           include Enumerable
 
-          def each
-            yield 1, 2
+          def initialize(values = [])
+            @values = values
+          end
+
+          # Required method for Enumerable
+          def each(&block)
+            return enum_for(:each) unless block_given?
+            @values.each(&block)
           end
         end
 
@@ -812,7 +818,17 @@ describe Injectable do
           returns MyCollection, of: Integer, nullable: false, allow_nils: false
 
           def call
-            MyCollection.new
+            MyCollection.new([1, 2])
+          end
+        end
+
+        class ReturnsMyWrongCollection
+          include Injectable
+
+          returns MyCollection, of: Integer, nullable: false, allow_nils: false
+
+          def call
+            MyCollection.new([1, 'a'])
           end
         end
       end
@@ -828,11 +844,17 @@ describe Injectable do
       it 'raises when collection contains wrong types' do
         expect do
           ReturnsWrongTypes.call
-        end.to raise_error(RuntimeError, /return collection contains a Integer, needs elements of/)
+        end.to raise_error(RuntimeError, /return collection contains a Integer at position 1, needs elements of ReturnUser/)
       end
 
       it 'accepts any Enumerable (ActiveRecord-like) collection' do
         expect { ReturnsMyCollection.call }.not_to raise_error
+      end
+
+      it 'raises when collection contains wrong types on Enumerable collections' do
+        expect do
+          ReturnsMyWrongCollection.call
+        end.to raise_error(RuntimeError, /return collection contains a String at position 1, needs elements of Integer/)
       end
     end
   end

--- a/spec/injectable_spec.rb
+++ b/spec/injectable_spec.rb
@@ -808,6 +808,7 @@ describe Injectable do
           # Required method for Enumerable
           def each(&block)
             return enum_for(:each) unless block_given?
+
             @values.each(&block)
           end
         end
@@ -844,7 +845,8 @@ describe Injectable do
       it 'raises when collection contains wrong types' do
         expect do
           ReturnsWrongTypes.call
-        end.to raise_error(RuntimeError, /return collection contains a Integer at position 1, needs elements of ReturnUser/)
+        end.to raise_error(RuntimeError,
+                           /return collection contains a Integer at position 1, needs elements of ReturnUser/)
       end
 
       it 'accepts any Enumerable (ActiveRecord-like) collection' do


### PR DESCRIPTION
Please, disregard the branch name 😮‍💨 

### Changes

### Add optional type checking to `argument` declarations

```rb
argument :jarl, type: Chiquito
argument :torpedo, type: Array, default: nil
```

### Add optional type checking to `returned` values

```rb
returns MyClass, nullable: true
returns MyCollection, of: Item, nullable: true, allow_nils: false
```

## Notes
 
Made them **optional**, since they're not the main purpose of the library, but happy to cut a 3.0.0 branch with **breaking** changes.

See each commit's README entries for more examples

```rb
class UserByPermissionsQuery
  include Injectable
  
  argument(:permission, type: Permission)
  dependency(:base_relation) { User.all }
  returns(ActiveRecord::Associations::CollectionProxy, of: User, nullable: false, allow_nils: false)

  def call
    base_relation.includes(:permissions).where(permissions: { id: permission.id })
  end
end
```

### About Collection validations

I've got a bit of a mess there. Not really sure I should check for Enumerable, or just `responds_to?(:each)` is enough?

Maybe having an optional `enumerates_with:` key is cool to indicate which method is used to iterate the collection (default `:each`)?

```rb
returns MyCollection, of: Item, enumerates_with: :each, nullable: false, allow_nils: false
```

