### PR TITLE
Fix simplecov setup

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,14 @@
+require 'simplecov-json'
+
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::JSONFormatter
+  ]
+)
+
+SimpleCov.start do
+  enable_coverage(:branch)
+
+  load_profile 'test_frameworks'
+end

--- a/lib/injectable/class_methods.rb
+++ b/lib/injectable/class_methods.rb
@@ -28,22 +28,26 @@ module Injectable
 
         ivar = "@#{name}"
 
+        # Define the instance reader immediately when this attribute is declared
+        # so instances always respond to the reader even if the singleton
+        # class value has not been set yet.
+        if singleton_class?
+          class_eval do
+            define_method(name) do
+              if instance_variable_defined? ivar
+                instance_variable_get ivar
+              else
+                singleton_class.send name
+              end
+            end
+          end
+        end
+
         define_singleton_method("#{name}=") do |val|
           singleton_class.class_eval do
             define_method(name) { val }
           end
 
-          if singleton_class?
-            class_eval do
-              define_method(name) do
-                if instance_variable_defined? ivar
-                  instance_variable_get ivar
-                else
-                  singleton_class.send name
-                end
-              end
-            end
-          end
           val
         end
       end

--- a/spec/injectable/class_methods_spec.rb
+++ b/spec/injectable/class_methods_spec.rb
@@ -1,0 +1,45 @@
+describe Injectable::ClassMethods do
+  describe '#simple_class_attribute' do
+    subject(:klass) do
+      Class.new do
+        include Injectable
+
+        def self.singleton_class?
+          true
+        end
+
+        class_eval do
+          simple_class_attribute :flag
+        end
+
+        def call
+          'jarl'
+        end
+      end
+    end
+
+    it 'defines instance reader delegating to singleton reader when singleton_class?' do
+      klass.flag = 'on'
+      expect(klass.flag).to eq('on')
+    end
+
+    it 'passes the singleton class attribute value to the instances' do
+      klass.flag = 'on'
+      instance = klass.new
+      expect(instance.flag).to eq('on')
+    end
+
+    it 'allows to modify attribute value on the instance', skip: 'Failing, need to investigate' do
+      instance = klass.new
+      instance.instance_variable_set('@flag', 'local')
+      expect(instance.flag).to eq('local')
+    end
+
+    it 'does not pass instance values up to the singleton class value' do
+      klass.flag = 'on'
+      instance = klass.new
+      instance.instance_variable_set('@flag', 'local')
+      expect(klass.flag).to eq 'on'
+    end
+  end
+end

--- a/spec/injectable/class_methods_spec.rb
+++ b/spec/injectable/class_methods_spec.rb
@@ -29,7 +29,7 @@ describe Injectable::ClassMethods do
       expect(instance.flag).to eq('on')
     end
 
-    it 'allows to modify attribute value on the instance', skip: 'Failing, need to investigate' do
+    it 'allows to modify attribute value on the instance' do
       instance = klass.new
       instance.instance_variable_set('@flag', 'local')
       expect(instance.flag).to eq('local')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,19 +1,6 @@
+require 'simplecov' if ENV['COVERAGE'] == 'true'
 require 'bundler/setup'
 require 'injectable'
-
-if ENV['COVERAGE'] == 'true'
-  require 'simplecov'
-  require 'simplecov-json'
-
-  SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
-                                                                    SimpleCov::Formatter::HTMLFormatter,
-                                                                    SimpleCov::Formatter::JSONFormatter
-                                                                  ])
-
-  SimpleCov.start do
-    enable_coverage(:branch)
-  end
-end
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
### Changes

👉 Improve simplecov config to address several issues:

- We were requiring simplecov AFTER injectable, so it was not tracking the project files properly. The coverage we were getting was from the spec files themselves.

| MASTER BRANCH | THIS BRANCH |
|-------------------|----------------|
| <img width="1450" height="684" alt="Captura de pantalla 2025-11-12 a las 19 04 00" src="https://github.com/user-attachments/assets/f480ae94-1723-405a-99e0-f9b1a1708590" /> | <img width="1439" height="754" alt="Captura de pantalla 2025-11-12 a las 19 03 28" src="https://github.com/user-attachments/assets/21182176-2ade-446f-8657-14600e50556d" /> |

👉  Extracted the config to the classic `.simplecov` file
👉 Added specs for an uncovered branch of the `class_methods.rb` file to bring covearege above 90%
👉 Refactors method on class_mehods.rb to get all specs passing.

### How to test:

1. checkout the branch
2. bundle install
3. COVERAGE=true bundle exec rspec
4. See the whole suite passes
5. open coverage/index.html
6. See the files displayed are the right ones